### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
@@ -21,7 +21,7 @@ jobs:
           ./tfsec-linux-amd64 example/examplea -f json --out tfsec.json
         continue-on-error: true
       - name: store
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfsec
           path: tfsec.json
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
@@ -42,7 +42,7 @@ jobs:
         run: checkov -d  example/examplea -o json | tee checkov.json
         continue-on-error: true
       - name: store
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: checkov
           path: checkov.json
@@ -51,12 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
           fetch-depth: '0'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
       - name: install terrascan
@@ -71,7 +71,7 @@ jobs:
           ./terrascan scan -d  example/examplea -o json -x json | tee terrascan.json
         continue-on-error: true
       - name: store
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terrascan
           path: terrascan.json
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
@@ -94,7 +94,7 @@ jobs:
         run: ./kics scan -p  example/examplea -o kics.json --report-formats json
         continue-on-error: true
       - name: store
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kics
           path: kics.json
@@ -106,17 +106,17 @@ jobs:
     steps:
       - name: Get Time
         id: time
-        uses: nanzm/get-time-action@v1.1
+        uses: nanzm/get-time-action@887e4db9af58ebae64998b7105921b816af77977 # v2.0
         with:
           timeZone: 8
           format: "YYYY-MM-DD-HH-mm-ss"
       - name: mkdir
         run: |
           mkdir  tos3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: tos3
-      - uses: jakejarvis/s3-sync-action@master
+      - uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 # v0.5.1
         with:
           args: --acl public-read --follow-symlinks --delete
         env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
@@ -21,7 +21,7 @@ jobs:
           echo 'plugin_cache_dir="$HOME/.terraform.d/plugin-cache"' >~/.terraformrc
           mkdir --parents ~/.terraform.d/plugin-cache
       - name: Cache Terraform
-        uses: actions/cache@v2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.terraform.d/plugin-cache
@@ -29,19 +29,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-terraform-
       - name: Terraform Init
-        uses: hashicorp/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@b2ca17c0c25198c67c668c37edcbc45ca086a91e # v0.8.0
         with:
           tf_actions_version: 1.3.0
           tf_actions_subcommand: init
           tf_actions_working_dir: example/examplea
       - name: Terraform Validate
-        uses: hashicorp/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@b2ca17c0c25198c67c668c37edcbc45ca086a91e # v0.8.0
         with:
           tf_actions_version: 1.3.0
           tf_actions_subcommand: validate
           tf_actions_working_dir: example/examplea
       - name: Terraform Plan
-        uses: hashicorp/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@b2ca17c0c25198c67c668c37edcbc45ca086a91e # v0.8.0
         with:
           tf_actions_version: 1.3.0
           tf_actions_subcommand: plan
@@ -53,12 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           token: ${{ github.token }}
           fetch-depth: '0'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
       - run: |
@@ -68,16 +68,16 @@ jobs:
           tar -xvf terraform-docs*.tar.gz --directory $GITHUB_WORKSPACE/bin
           chmod +x $GITHUB_WORKSPACE/bin/terraform-docs
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   version:
     name: versioning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: '0'
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.38.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
           fetch-depth: '0'
       - name: Terraform Init
-        uses: hashicorp/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@b2ca17c0c25198c67c668c37edcbc45ca086a91e # v0.8.0
         with:
           tf_actions_version: 1.3.0
           tf_actions_subcommand: init
           tf_actions_working_dir: example/examplea
       - name: Terraform Validate
-        uses: hashicorp/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@b2ca17c0c25198c67c668c37edcbc45ca086a91e # v0.8.0
         with:
           tf_actions_version: 1.3.0
           tf_actions_subcommand: validate
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
           fetch-depth: '0'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
   python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -20,35 +20,35 @@ repos:
           - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8 # v1.5.6
     hooks:
       - id: forbid-tabs
         exclude_types: [python, javascript, dtd, markdown, makefile, xml]
         exclude: binary|\.bin$
   - repo: https://github.com/jameswoolfenden/pre-commit-shell
-    rev: 0.0.2
+    rev: 062f0b028ae65827e04f91c1e6738cfcbe9b337f # v1.0.6
     hooks:
       - id: shell-lint
         exclude: template|\.template$
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.35.0
+    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e # v0.48.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/jameswoolfenden/pre-commit
-    rev: v0.1.50
+    rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
     hooks:
       - id: terraform-fmt
         language_version: python3.8
       - id: tf2docs
         language_version: python3.8
   - repo: https://github.com/bridgecrewio/checkov
-    rev: 2.3.347
+    rev: e52a901a3829d818d20c9b75e544845c8b756968 # 3.2.526
     hooks:
       - id: checkov
         verbose: true
         entry: checkov -d example/examplea --external-checks-dir checkov --download-external-modules true
   - repo: https://github.com/jameswoolfenden/pike
-    rev: v0.2.81
+    rev: d043242b9e1733e9e5a67c20bb87c05a4d563596 # v0.4.1
     hooks:
       - id: pike-docs-go
         args: ["readme","-i","-d", "." ]

--- a/aws_iam_role.dax.tf
+++ b/aws_iam_role.dax.tf
@@ -1,46 +1,46 @@
 resource "aws_iam_role" "dax" {
   name_prefix = "DAXServiceRoleForDynamoDBAccess"
   assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-       {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "dax.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-        }
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "dax.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
     ]
-})
-tags = var.common_tags
+  })
+  tags = var.common_tags
 }
 
 
 resource "aws_iam_role_policy" "dax" {
-    role = aws_iam_role.dax.name
-    policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "dynamodb:DescribeTable",
-                "dynamodb:PutItem",
-                "dynamodb:GetItem",
-                "dynamodb:UpdateItem",
-                "dynamodb:DeleteItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "dynamodb:BatchGetItem",
-                "dynamodb:BatchWriteItem",
-                "dynamodb:ConditionCheckItem"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:dynamodb:us-west-2:${data.aws_caller_identity.current.account_id}:*"
-            ]
-        }
+  role = aws_iam_role.dax.name
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "dynamodb:DescribeTable",
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:BatchGetItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:ConditionCheckItem"
+        ],
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:dynamodb:us-west-2:${data.aws_caller_identity.current.account_id}:*"
+        ]
+      }
     ]
-})
+  })
 
 }
 

--- a/aws_security_group.dax.tf
+++ b/aws_security_group.dax.tf
@@ -1,24 +1,24 @@
 resource "aws_security_group" "dax" {
-    name = var.cluster["cluster_name"]
-    description = "DAX cluster sg"
-    ingress  {
-      cidr_blocks = var.vpc_cidr
-      description = "unencryted dax"
-      from_port = 8111
-      protocol = "tcp"
-      to_port = 8111
-    }
+  name        = var.cluster["cluster_name"]
+  description = "DAX cluster sg"
+  ingress {
+    cidr_blocks = var.vpc_cidr
+    description = "unencryted dax"
+    from_port   = 8111
+    protocol    = "tcp"
+    to_port     = 8111
+  }
 
-    ingress {
-      cidr_blocks =  var.vpc_cidr
-      description = "encryted dax"
-      from_port = 9111
-      protocol = "tcp"
-      to_port = 9111
-    }
+  ingress {
+    cidr_blocks = var.vpc_cidr
+    description = "encryted dax"
+    from_port   = 9111
+    protocol    = "tcp"
+    to_port     = 9111
+  }
 }
 
 
 variable "vpc_cidr" {
-  type=list(string)
+  type = list(string)
 }

--- a/example/examplea/terraform.tf
+++ b/example/examplea/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "4.34.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">=1.3.0"


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.